### PR TITLE
fix: missing serverless-ecs-image-handler-stack

### DIFF
--- a/source/constructs/bin/constructs.ts
+++ b/source/constructs/bin/constructs.ts
@@ -3,19 +3,19 @@
 
 import * as cdk from '@aws-cdk/core';
 import { BootstraplessStackSynthesizer } from 'cdk-bootstrapless-synthesizer';
-import { ConstructsStack, /* ECSImageHandlerStack,*/ LambdaImageHandlerStack } from '../lib/constructs-stack';
+import { ConstructsStack, ECSImageHandlerStack, LambdaImageHandlerStack } from '../lib/constructs-stack';
 
 const app = new cdk.App();
 new ConstructsStack(app, 'ConstructsStack');
-// const ecsStack = new ECSImageHandlerStack(app, 'serverless-ecs-image-handler-stack', {
-//   stackName: process.env.STACK_NAME,
-//   env: {
-//     account: process.env.CDK_DEFAULT_ACCOUNT,
-//     region: process.env.CDK_DEPLOY_REGION,
-//   },
-// });
+const ecsStack = new ECSImageHandlerStack(app, 'serverless-ecs-image-handler-stack', {
+  stackName: process.env.STACK_NAME,
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEPLOY_REGION,
+  },
+});
 
-// cdk.Tags.of(ecsStack).add('name', 'serverless-ecs-image-handler');
+cdk.Tags.of(ecsStack).add('name', 'serverless-ecs-image-handler');
 
 new LambdaImageHandlerStack(app, 'lambda-image-handler-cn', {
   isChinaRegion: true,


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->



**Description of changes:**
<!-- Please describe the changes you made -->


**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
