### PR TITLE
add support for 3rd party origin

### DIFF
--- a/source/new-image-handler/src/config.ts
+++ b/source/new-image-handler/src/config.ts
@@ -14,6 +14,7 @@ const conf: IConfig = {
   srcBucket: process.env.BUCKET || process.env.SRC_BUCKET || 'sih-input',
   styleTableName: process.env.STYLE_TABLE_NAME || 'style-table-name',
   autoWebp: ['yes', '1', 'true'].includes((process.env.AUTO_WEBP ?? '').toLowerCase()),
+  extOrigin: process.env.EXT_ORIGIN,
 };
 
 export default conf;

--- a/source/new-image-handler/src/default.ts
+++ b/source/new-image-handler/src/default.ts
@@ -3,7 +3,7 @@ import { ParsedUrlQuery } from 'querystring';
 import config from './config';
 import { InvalidArgument, IProcessor } from './processor';
 import { ImageProcessor, StyleProcessor } from './processor/image';
-import { IBufferStore, S3Store, LocalStore, MemKVStore, DynamoDBStore, IKVStore } from './store';
+import { IBufferStore, S3Store, LocalStore, MemKVStore, DynamoDBStore, IKVStore, HTTPStore } from './store';
 import * as style from './style.json';
 
 const PROCESSOR_MAP: { [key: string]: IProcessor } = {
@@ -20,11 +20,16 @@ export function getProcessor(name: string): IProcessor {
 }
 
 export function bufferStore(p?: string): IBufferStore {
-  if (config.isProd) {
+  if (config.isProd && !config.extOrigin) {
     if (!p) { p = config.srcBucket; }
     console.log(`use ${S3Store.name} s3://${p}`);
     return new S3Store(p);
-  } else {
+  } 
+  // 3rd origin
+  else if (config.isProd && config.extOrigin){
+    return HTTPStore(p);
+  }
+  else {
     if (!p) { p = path.join(__dirname, '../test/fixtures'); }
     console.log(`use ${LocalStore.name} file://${p}`);
     return new LocalStore(p);

--- a/source/new-image-handler/src/store.ts
+++ b/source/new-image-handler/src/store.ts
@@ -66,6 +66,25 @@ export class S3Store implements IBufferStore {
   }
 }
 
+
+/**
+ * A http(s) base store, used for 3rd party origin
+ */
+ export class HTTPStore implements IBufferStore {
+  public constructor(public readonly bucket: string) { }
+
+  public async get(p: string, _?: () => void): Promise<{ buffer: Buffer; type: string }> {
+    const imgUrl = path.join(config.extOrigin, p);
+    var request = require('request').defaults({ encoding: null });
+    request.get(imgUrl, function (err, res, body) {
+      return {
+        buffer: body,
+        type: res.ContentType ?? '',
+      };
+    });
+  }
+}
+
 /**
  * A fake store. Only for unit test.
  */


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->

Support 3rd party HTTP(s) server as origin

**Description of changes:**
<!-- Please describe the changes you made -->

Support 3rd party HTTP(s) server as origin, to support CX leverage CloudFront as CDN while keep 3rd party HTTP(s) server as origin.


**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
