### PR TITLE
Fix Bug: When action **format** is called before the **quality** action.

### DIFF
--- a/source/new-image-handler/src/processor/image/quality.ts
+++ b/source/new-image-handler/src/processor/image/quality.ts
@@ -46,8 +46,7 @@ export class QualityAction implements IImageAction {
   }
   public async process(ctx: IImageContext, params: string[]): Promise<void> {
     const opt = this.validate(params);
-    const metadata = await ctx.image.metadata();
-
+    const metadata = await sharp(await ctx.image.toBuffer()).metadata(); // If the formate is changed before.
     if (JPEG === metadata.format || JPG === metadata.format) {
       let q = 72;
       if (opt.q) {


### PR DESCRIPTION
 The current processor would still think it is origional formate - like jpeg, but it is not. It would cause exception. The fix is to retrive the formate from buffer again.

**Issue #, if available:**
If format is changed to _webp_ then the following _quality_ action would fail.


**Description of changes:**
<!-- Please describe the changes you made -->


**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
