### PR TITLE
Set the secret manager for post as optional

### DIFF
--- a/source/constructs/lib/ecs-image-handler.ts
+++ b/source/constructs/lib/ecs-image-handler.ts
@@ -56,7 +56,7 @@ export class ECSImageHandler extends Construct {
           VIPS_DISC_THRESHOLD: '600m', // https://github.com/lovell/sharp/issues/1851
           SRC_BUCKET: buckets[0].bucketName,
           STYLE_TABLE_NAME: table.tableName,
-          SECRET_NAME: secret.secretArn,
+          SECRET_NAME: secret?.secretArn,
         }, scope.node.tryGetContext('env')),
       },
     });
@@ -88,7 +88,7 @@ export class ECSImageHandler extends Construct {
       }));
     }
 
-    secret.grantRead(albFargateService.taskDefinition.taskRole);
+    secret?.grantRead(albFargateService.taskDefinition.taskRole);
 
     // TODO: Add restriction access to ALB
     // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/restrict-access-to-load-balancer.html
@@ -220,14 +220,15 @@ function getBuckets(scope: Construct, id: string): s3.IBucket[] {
   return buckets.map((bkt: string, index: number) => s3.Bucket.fromBucketName(scope, `${id}${index}`, bkt));
 }
 
-function getSecret(scope: Construct): secretsmanager.ISecret {
+function getSecret(scope: Construct): secretsmanager.ISecret | undefined {
   const secretArn = scope.node.tryGetContext('secret_arn');
   if (!!secretArn) {
     return secretsmanager.Secret.fromSecretAttributes(scope, 'ImportedSecret', {
       secretArn: secretArn,
     });
   } else {
-    throw new Error('You must specify one secret manager arn for POST security.');
+    console.warn('You may specify one secret manager arn for POST security.');
+    return undefined;
   }
 }
 


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
https://github.com/wchaws/serverless-image-handler/issues/135


**Description of changes:**
<!-- Please describe the changes you made -->
Set the secret manager for post as optional

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
