### PR TITLE
chore: upgrade sharp to v0.31.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '12' ]
+        node: [ '14' ]
     name: Node ${{ matrix.node }}
     defaults:
       run:

--- a/source/new-image-handler/Dockerfile
+++ b/source/new-image-handler/Dockerfile
@@ -1,4 +1,4 @@
-# FROM public.ecr.aws/docker/library/node:14-slim as node-with-vips
+# FROM public.ecr.aws/docker/library/node:14-alpine3.16 as node-with-vips
 
 # ARG VIPS_VERSION=8.11.3
 
@@ -24,14 +24,15 @@
 #     # && apk del --purge vips-dependencies \
 #     && rm -rf /var/cache/apk/*
 
-FROM public.ecr.aws/docker/library/node:14-slim as builder
+FROM public.ecr.aws/docker/library/node:14-alpine3.16 as builder
 
 WORKDIR /app
 
 COPY package.json yarn.lock /app/
 
-RUN apt update -y && \
-    apt install -y fontconfig
+# FIXME: try to remove font-noto when https://github.com/lovell/sharp/issues/3393 is fixed.
+RUN apk update && \
+    apk add fontconfig font-noto
 
 RUN yarn
 
@@ -40,15 +41,16 @@ COPY . .
 RUN yarn build
 
 
-FROM public.ecr.aws/docker/library/node:14-slim
+FROM public.ecr.aws/docker/library/node:14-alpine3.16
 
 WORKDIR /app
 
 COPY package.json yarn.lock /app/
 COPY ./fonts/* /usr/share/fonts/
 
-RUN apt update -y && \
-    apt install -y fontconfig ffmpeg
+# FIXME: try to remove font-noto when https://github.com/lovell/sharp/issues/3393 is fixed.
+RUN apk update && \
+    apk add fontconfig font-noto ffmpeg
 
 ENV NODE_ENV=production
 

--- a/source/new-image-handler/Dockerfile
+++ b/source/new-image-handler/Dockerfile
@@ -1,4 +1,4 @@
-# FROM node:14-alpine3.16 as node-with-vips
+# FROM public.ecr.aws/docker/library/node:14-slim as node-with-vips
 
 # ARG VIPS_VERSION=8.11.3
 
@@ -24,14 +24,14 @@
 #     # && apk del --purge vips-dependencies \
 #     && rm -rf /var/cache/apk/*
 
-FROM node:14-alpine3.16 as builder
+FROM public.ecr.aws/docker/library/node:14-slim as builder
 
 WORKDIR /app
 
 COPY package.json yarn.lock /app/
 
-RUN apk update && \
-    apk add fontconfig
+RUN apt update -y && \
+    apt install -y fontconfig
 
 RUN yarn
 
@@ -40,15 +40,15 @@ COPY . .
 RUN yarn build
 
 
-FROM node:14-alpine3.16
+FROM public.ecr.aws/docker/library/node:14-slim
 
 WORKDIR /app
 
 COPY package.json yarn.lock /app/
 COPY ./fonts/* /usr/share/fonts/
 
-RUN apk update && \
-    apk add fontconfig ffmpeg
+RUN apt update -y && \
+    apt install -y fontconfig ffmpeg
 
 ENV NODE_ENV=production
 

--- a/source/new-image-handler/Dockerfile
+++ b/source/new-image-handler/Dockerfile
@@ -1,4 +1,4 @@
-# FROM node:12-alpine3.12 as node-with-vips
+# FROM node:14-alpine3.16 as node-with-vips
 
 # ARG VIPS_VERSION=8.11.3
 
@@ -24,7 +24,7 @@
 #     # && apk del --purge vips-dependencies \
 #     && rm -rf /var/cache/apk/*
 
-FROM node:12-alpine3.12 as builder
+FROM node:14-alpine3.16 as builder
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ COPY . .
 RUN yarn build
 
 
-FROM node:12-alpine3.12
+FROM node:14-alpine3.16
 
 WORKDIR /app
 

--- a/source/new-image-handler/Dockerfile.dev
+++ b/source/new-image-handler/Dockerfile.dev
@@ -49,8 +49,9 @@ WORKDIR /app
 COPY package.json yarn.lock /app/
 COPY ./fonts/* /usr/share/fonts/
 
+# FIXME: try to remove font-noto when https://github.com/lovell/sharp/issues/3393 is fixed.
 RUN apt update -y && \
-    apt install -y fontconfig ffmpeg
+    apt install -y fontconfig font-noto ffmpeg
 
 # ENV NODE_ENV=production
 

--- a/source/new-image-handler/Dockerfile.dev
+++ b/source/new-image-handler/Dockerfile.dev
@@ -1,4 +1,4 @@
-# FROM node:14-alpine3.16 as node-with-vips
+# FROM public.ecr.aws/docker/library/node:14-slim as node-with-vips
 
 # ARG VIPS_VERSION=8.11.3
 
@@ -42,15 +42,15 @@
 # RUN yarn build
 
 
-FROM node:14-alpine3.16
+FROM public.ecr.aws/docker/library/node:14-slim
 
 WORKDIR /app
 
 COPY package.json yarn.lock /app/
 COPY ./fonts/* /usr/share/fonts/
 
-RUN apk update && \
-    apk add fontconfig ffmpeg
+RUN apt update -y && \
+    apt install -y fontconfig ffmpeg
 
 # ENV NODE_ENV=production
 

--- a/source/new-image-handler/Dockerfile.dev
+++ b/source/new-image-handler/Dockerfile.dev
@@ -1,4 +1,4 @@
-# FROM node:12-alpine3.12 as node-with-vips
+# FROM node:14-alpine3.16 as node-with-vips
 
 # ARG VIPS_VERSION=8.11.3
 
@@ -42,7 +42,7 @@
 # RUN yarn build
 
 
-FROM node:12-alpine3.12
+FROM node:14-alpine3.16
 
 WORKDIR /app
 

--- a/source/new-image-handler/Dockerfile.lambda
+++ b/source/new-image-handler/Dockerfile.lambda
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/sam/build-nodejs12.x
+FROM public.ecr.aws/sam/build-nodejs14.x
 
 WORKDIR /app
 

--- a/source/new-image-handler/Dockerfile.lambda.deps
+++ b/source/new-image-handler/Dockerfile.lambda.deps
@@ -1,4 +1,4 @@
-# FROM public.ecr.aws/sam/build-nodejs12.x as ImageMagickBuilder
+# FROM public.ecr.aws/sam/build-nodejs14.x as ImageMagickBuilder
 
 # WORKDIR /ws
 
@@ -13,7 +13,7 @@
 # RUN make -f ImageMagick.Makefile all TARGET_DIR=/opt
 
 
-FROM public.ecr.aws/sam/build-nodejs12.x
+FROM public.ecr.aws/sam/build-nodejs14.x
 
 WORKDIR /app
 

--- a/source/new-image-handler/package.json
+++ b/source/new-image-handler/package.json
@@ -27,7 +27,7 @@
     "@types/koa-logger": "^3.1.2",
     "@types/koa-router": "^7.4.4",
     "@types/node": "^14.18.16",
-    "@types/sharp": "^0.30.2",
+    "@types/sharp": "^0.31.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "benchmark": "^2.1.4",
@@ -52,7 +52,7 @@
     "koa-bodyparser": "^4.3.0",
     "koa-logger": "^3.2.1",
     "koa-router": "^10.1.1",
-    "sharp": "^0.30.4"
+    "sharp": "^0.31.1"
   },
   "bundledDependencies": [],
   "engines": {

--- a/source/new-image-handler/test/index-lambda.test.ts
+++ b/source/new-image-handler/test/index-lambda.test.ts
@@ -95,7 +95,7 @@ test('index-lambda.ts example.gif?x-oss-process=image/resize,w_100/quality,q_50'
 
   expect(metadata.width).toBe(100);
   expect(metadata.height).toBe(60);
-  expect(metadata.size).toBe(3820);
+  expect(metadata.size).toBe(3544);
   expect(metadata.format).toBe('gif');
   expect(metadata.pages).toBe(3);
 });

--- a/source/new-image-handler/test/processor/index.test.ts
+++ b/source/new-image-handler/test/processor/index.test.ts
@@ -224,7 +224,7 @@ test('f.jpg?x-oss-process=image/resize,w_100/', async () => {
 
   expect(type).toBe('image/jpeg');
   expect(metadata.width).toBe(100);
-  expect(metadata.height).toBe(128);
+  expect(metadata.height).toBe(127);
 });
 
 test('f.jpg?x-oss-process=image/resize,w_100/auto-orient,0', async () => {

--- a/source/new-image-handler/yarn.lock
+++ b/source/new-image-handler/yarn.lock
@@ -1238,10 +1238,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/sharp@^0.30.2":
-  version "0.30.2"
-  resolved "https://registry.yarnpkg.com/@types/sharp/-/sharp-0.30.2.tgz#df5ff34140b3bad165482e6f3d26b08e42a0503a"
-  integrity sha512-uLCBwjDg/BTcQit0dpNGvkIjvH3wsb8zpaJePCjvONBBSfaKHoxXBIuq1MT8DMQEfk2fKYnpC9QExCgFhkGkMQ==
+"@types/sharp@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@types/sharp/-/sharp-0.31.0.tgz#c4af03a7e1d126f0d428a265e126fabd86ab6d0f"
+  integrity sha512-nwivOU101fYInCwdDcH/0/Ru6yIRXOpORx25ynEOc6/IakuCmjOAGpaO5VfUl4QkDtUC6hj+Z2eCQvgXOioknw==
   dependencies:
     "@types/node" "*"
 
@@ -4691,10 +4691,10 @@ node-abi@^3.3.0:
   dependencies:
     semver "^7.3.5"
 
-node-addon-api@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
-  integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
+node-addon-api@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
+  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
 
 node-gyp@^7.1.0:
   version "7.1.2"
@@ -4862,7 +4862,7 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -5231,10 +5231,10 @@ pngjs@^3.0.0, pngjs@^3.3.3:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
 
-prebuild-install@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.0.tgz#991b6ac16c81591ba40a6d5de93fb33673ac1370"
-  integrity sha512-CNcMgI1xBypOyGqjp3wOc8AAo1nMhZS3Cwd3iHIxOdAUbb+YxdNuM4Z5iIrZ8RLvOsf3F3bl7b7xGq6DjQoNYA==
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
   dependencies:
     detect-libc "^2.0.0"
     expand-template "^2.0.3"
@@ -5243,7 +5243,6 @@ prebuild-install@^7.0.1:
     mkdirp-classic "^0.5.3"
     napi-build-utils "^1.0.1"
     node-abi "^3.3.0"
-    npmlog "^4.0.1"
     pump "^3.0.0"
     rc "^1.2.7"
     simple-get "^4.0.0"
@@ -5656,15 +5655,15 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sharp@^0.30.4:
-  version "0.30.4"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.30.4.tgz#73d9daa63bbc20da189c9328d75d5d395fc8fb73"
-  integrity sha512-3Onig53Y6lji4NIZo69s14mERXXY/GV++6CzOYx/Rd8bnTwbhFbL09WZd7Ag/CCnA0WxFID8tkY0QReyfL6v0Q==
+sharp@^0.31.1:
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.31.1.tgz#b2f7076d381a120761aa93700cadefcf90a22458"
+  integrity sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==
   dependencies:
     color "^4.2.3"
     detect-libc "^2.0.1"
-    node-addon-api "^4.3.0"
-    prebuild-install "^7.0.1"
+    node-addon-api "^5.0.0"
+    prebuild-install "^7.1.1"
     semver "^7.3.7"
     simple-get "^4.0.1"
     tar-fs "^2.1.1"


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->



**Description of changes:**
<!-- Please describe the changes you made -->

@tingxin
there're some issue's upgrading to sharp v0.31.1
1. using svg `<text>` will trigger the follow bug: https://github.com/lovell/sharp/issues/3393  (workaround: add font-noto in dockerfile)
3. node version must be > 14.0.0 (upgrade node version to v14)

**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
