### PR TITLE
fix: disable gif enlarge and reduce high resolution png size

### DIFF
--- a/source/new-image-handler/src/processor/image/auto-orient.ts
+++ b/source/new-image-handler/src/processor/image/auto-orient.ts
@@ -13,6 +13,12 @@ export class AutoOrientAction extends BaseImageAction {
     ctx.features[Features.AutoOrient] = false;
   }
 
+  public beforeProcess(ctx: IImageContext, _2: string[], index: number): void {
+    if ('gif' === ctx.metadata.format) {
+      ctx.mask.disable(index);
+    }
+  }
+
   public validate(params: string[]): ReadOnly<AutoOrientOpts> {
     const opt: AutoOrientOpts = { auto: false };
 

--- a/source/new-image-handler/src/processor/image/interlace.ts
+++ b/source/new-image-handler/src/processor/image/interlace.ts
@@ -24,6 +24,11 @@ export class InterlaceAction extends BaseImageAction {
     return opt;
   }
 
+  public beforeProcess(ctx: IImageContext, _2: string[], index: number): void {
+    if ('gif' === ctx.metadata.format) {
+      ctx.mask.disable(index);
+    }
+  }
 
   public async process(ctx: IImageContext, params: string[]): Promise<void> {
     const opt = this.validate(params);

--- a/source/new-image-handler/src/processor/image/interlace.ts
+++ b/source/new-image-handler/src/processor/image/interlace.ts
@@ -27,7 +27,7 @@ export class InterlaceAction extends BaseImageAction {
 
   public async process(ctx: IImageContext, params: string[]): Promise<void> {
     const opt = this.validate(params);
-    const metadata = await ctx.image.metadata();
+    const metadata = ctx.metadata;
     if (('jpg' === metadata.format || 'jpeg' === metadata.format) && opt.interlace) {
       ctx.image.jpeg({ progressive: true });
     }

--- a/source/new-image-handler/src/processor/image/resize.ts
+++ b/source/new-image-handler/src/processor/image/resize.ts
@@ -122,6 +122,14 @@ export class ResizeAction extends BaseImageAction {
       }
     }
 
+    if ('gif' === metadata.format) {
+      const isEnlargingWidth = (opt.width && opt.width > metadata.width);
+      const isEnlargingHeight = (opt.height && metadata.pageHeight && (opt.height > metadata.pageHeight));
+      if (isEnlargingWidth || isEnlargingHeight) {
+        return;
+      }
+    }
+
     ctx.image.resize(null, null, opt);
   }
 }


### PR DESCRIPTION
0779ac46961491aaa1fa0a1fa3b48c79_6802770812466820349.gif?x-oss-process=image/resize,s_1000/quality,q_80/auto-orient,0/interlace,1/format,gif 1.PNG?x-oss-process=image/strip-metadata

**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->

Fix: #160 
Fix: #159 

**Description of changes:**
<!-- Please describe the changes you made -->


**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
